### PR TITLE
[codex-cli] allow env provider

### DIFF
--- a/codex-cli/README.md
+++ b/codex-cli/README.md
@@ -117,6 +117,24 @@ export OPENAI_API_KEY="your-api-key-here"
 > export <provider>_API_KEY="your-api-key-here"
 > ```
 >
+> Alternatively you can set the provider via the `LLM_PROVIDER` environment
+> variable:
+>
+> ```shell
+> export LLM_PROVIDER=<provider>
+> ```
+>
+> For Gemini you can provide multiple API keys by setting
+> `GEMINI_API_KEYS` to a comma-separated list. Keys will be used in
+> round-robin order.
+>
+> A helper script at `scripts/run_gemini.sh` sets `LLM_PROVIDER=gemini` and can
+> accept a comma-separated key list for quick startup:
+>
+> ```bash
+> ./scripts/run_gemini.sh "key1,key2,key3"
+> ```
+>
 > If you use a provider not listed above, you must also set the base URL for the provider:
 >
 > ```shell

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -292,7 +292,12 @@ let config = loadConfig(undefined, undefined, {
 let prompt = cli.input[0];
 const model = cli.flags.model ?? config.model;
 const imagePaths = cli.flags.image;
-const provider = cli.flags.provider ?? config.provider ?? "openai";
+// Allow overriding the provider via environment variable for convenience.
+const provider =
+  process.env["LLM_PROVIDER"] ??
+  cli.flags.provider ??
+  config.provider ??
+  "openai";
 
 const client = {
   issuer: "https://auth.openai.com",

--- a/scripts/run_gemini.sh
+++ b/scripts/run_gemini.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Simple helper to launch Codex CLI using Gemini provider with optional key rotation
+
+if [ -z "$GEMINI_API_KEYS" ] && [ -n "$1" ]; then
+  export GEMINI_API_KEYS="$1"
+  shift
+fi
+
+# Default to gemini provider
+export LLM_PROVIDER=gemini
+
+# Forward all args to codex CLI
+npx codex "$@"


### PR DESCRIPTION
## Summary
- let Codex CLI read provider from `LLM_PROVIDER`
- document `LLM_PROVIDER` and helper script usage

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: rawExec – abort kills entire process group)*
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873f0163d20832fbe09579823574d3b